### PR TITLE
[docs] Fix docs for CLI options

### DIFF
--- a/packages/markmap-cli/README.md
+++ b/packages/markmap-cli/README.md
@@ -29,10 +29,9 @@ Create a markmap from a Markdown input file
 
 Options:
   -V, --version          output the version number
-  -o, --output <output>  specify filename of the output HTML
-  --enable-mathjax       enable MathJax support
-  --enable-prism         enable PrismJS support
   --no-open              do not open the output file after generation
+  --no-toolbar           do not show toolbar
+  -o, --output <output>  specify filename of the output HTML
   -w, --watch            watch the input file and update output on the fly, note that this feature is for development only
   -h, --help             display help for command
 ```


### PR DESCRIPTION
When running markmap-cli locally (version 0.5.3) I see these CLI options in `markmap -h`.
Potentially what is documented in this README was outdated?

Especially the `--no-toolbar` option seemed to be missing.

Not sure what happened to `--enable-mathjax` and `--enable-prism`. 
Are these maybe always enabled now (and hence the CLI options were removed)?