### PR TITLE
feat: support headings beyond h6 (up to h10)

### DIFF
--- a/packages/markmap-html-parser/src/index.ts
+++ b/packages/markmap-html-parser/src/index.ts
@@ -9,6 +9,10 @@ export enum Levels {
   H4,
   H5,
   H6,
+  H7,
+  H8,
+  H9,
+  H10,
   Block,
   List,
   ListItem,
@@ -56,7 +60,7 @@ const defaultSelectorRules: IHtmlParserSelectorRules = {
   'div,p': ({ $node }) => ({
     queue: $node.children(),
   }),
-  'h1,h2,h3,h4,h5,h6': ({ $node, getContent }) => ({
+  'h1,h2,h3,h4,h5,h6,h7,h8,h9,h10': ({ $node, getContent }) => ({
     ...getContent($node.contents()),
   }),
   'ul,ol': ({ $node }) => ({
@@ -86,17 +90,19 @@ const defaultSelectorRules: IHtmlParserSelectorRules = {
 };
 
 export const defaultOptions: IHtmlParserOptions = {
-  selector: 'h1,h2,h3,h4,h5,h6,ul,ol,li,table,pre,p>img:only-child',
+  selector:
+    'h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,ul,ol,li,table,pre,p>img:only-child',
   selectorRules: defaultSelectorRules,
 };
 
 const MARKMAP_COMMENT_PREFIX = 'markmap: ';
-const SELECTOR_HEADING = /^h[1-6]$/;
+const SELECTOR_HEADING = /^h(\d+)$/;
 const SELECTOR_LIST = /^[uo]l$/;
 const SELECTOR_LIST_ITEM = /^li$/;
 
 function getLevel(tagName: string) {
-  if (SELECTOR_HEADING.test(tagName)) return +tagName[1] as Levels;
+  const match = tagName.match(SELECTOR_HEADING);
+  if (match) return +match[1] as Levels;
   if (SELECTOR_LIST.test(tagName)) return Levels.List;
   if (SELECTOR_LIST_ITEM.test(tagName)) return Levels.ListItem;
   return Levels.Block;
@@ -211,7 +217,7 @@ export function parseHtml(html: string, opts?: Partial<IHtmlParserOptions>) {
       }
       const level = getLevel(child.tagName);
       if (!result) {
-        if (level <= Levels.H6) {
+        if (level <= Levels.H10) {
           skippingHeading = level;
         }
         return;
@@ -219,7 +225,7 @@ export function parseHtml(html: string, opts?: Partial<IHtmlParserOptions>) {
       if (skippingHeading > Levels.None && level > skippingHeading) return;
       if (!$child.is(options.selector)) return;
       skippingHeading = Levels.None;
-      const isHeading = level <= Levels.H6;
+      const isHeading = level <= Levels.H10;
       let data = {
         // If the child is an inline element and expected to be a separate node,
         // data from the closest `<p>` should be included, e.g. `<p data-lines><img /></p>`

--- a/packages/markmap-lib/src/markdown-it.ts
+++ b/packages/markmap-lib/src/markdown-it.ts
@@ -4,11 +4,37 @@ import md_mark from 'markdown-it-mark';
 import md_sub from 'markdown-it-sub';
 import md_sup from 'markdown-it-sup';
 
+function extendedHeadingsPlugin(md) {
+  const originalRender = md.render.bind(md);
+  md.render = function (src, env) {
+    let result = originalRender(src, env);
+    // Convert paragraphs containing 7+ hashes to proper headings
+    result = result.replace(
+      /<p([^>]*)>([\s\S]*?)<\/p>/g,
+      (_, attrs, content) => {
+        if (!/#{7,}/.test(content)) return _;
+        const lines = content.split(/<br\s*\/?>/gi);
+        return lines
+          .map((line) => {
+            const m = line.trim().match(/^(#{7,})\s*(.*)/);
+            if (m) {
+              return `<h${m[1].length}>${m[2].trim()}</h${m[1].length}>`;
+            }
+            return `<p${attrs}>${line}</p>`;
+          })
+          .join('');
+      },
+    );
+    return result;
+  };
+}
+
 export function initializeMarkdownIt() {
   const md = MarkdownIt({
     html: true,
     breaks: true,
   });
   md.use(md_ins).use(md_mark).use(md_sub).use(md_sup);
+  md.use(extendedHeadingsPlugin);
   return md;
 }


### PR DESCRIPTION
## Summary
- Add `extendedHeadingsPlugin` to markdown-it to convert 7+ hash headings to proper h7-h10 tags
- Extend `Levels` enum and selector rules to support h1-h10
- Update `SELECTOR_HEADING` regex to match any digit level

## Test plan
- Verified that markdown with 8+ hash headings (e.g., `######## H8`) now correctly renders in markmap
- Node tree structure correctly shows nested h7, h8, h9, h10 nodes