### PR TITLE
Approve esbuild and nx as pnpm built dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 engine-strict=true
+onlyBuiltDependencies[]=esbuild
+onlyBuiltDependencies[]=nx

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "build:js": "pnpm -r build:js",
     "build:docs": "typedoc --out api --titleLink / --name markmap"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild", "nx"]
+  },
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
-  - "packages/*"
+  - packages/*
+
+approveBuilds: esbuild,nx


### PR DESCRIPTION
✨ What changed
- Approved esbuild and nx as built dependencies in pnpm configuration
- Added the approval in three places: .npmrc, package.json, and the workspace config

💭 Why
- pnpm 10+ requires explicit approval for packages that run install scripts (postinstall, etc.)
- Without this, `pnpm install` would skip building esbuild and nx, breaking the build toolchain

👤 For users
- No user-facing changes

🔧 For operators
- After pulling this change, `pnpm install` will build esbuild and nx without prompts or warnings
- No other operator impact

🧪 How to test
1. Run `pnpm install` on a clean node_modules
2. Verify no warnings about unapproved built dependencies
3. Run `pnpm build` and confirm it completes successfully