### PR TITLE
docs(readme): add AI agents entry for mindmap-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Markmap is also available in:
   - [markmap.vim](https://github.com/Zeioth/markmap.nvim): for using without [coc.nvim](https://github.com/neoclide/coc.nvim)
 - Emacs: [eaf-markmap](https://github.com/emacs-eaf/eaf-markmap) -- powered by [EAF](https://github.com/emacs-eaf/emacs-application-framework)
 - MCP Server: [markmap-mcp-server](https://github.com/jinzcdev/markmap-mcp-server) [![NPM Version](https://img.shields.io/npm/v/@jinzcdev/markmap-mcp-server.svg)](https://www.npmjs.com/package/@jinzcdev/markmap-mcp-server) - powered by [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
+- AI coding agents: [mindmap-skills](https://github.com/galiacheng/mindmap-skills) - powered by [Claude Code](https://docs.claude.com/en/docs/claude-code) and [GitHub Copilot CLI](https://docs.github.com/copilot/concepts/agents/copilot-cli) skills
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Markmap is also available in:
   - [markmap.vim](https://github.com/Zeioth/markmap.nvim): for using without [coc.nvim](https://github.com/neoclide/coc.nvim)
 - Emacs: [eaf-markmap](https://github.com/emacs-eaf/eaf-markmap) -- powered by [EAF](https://github.com/emacs-eaf/emacs-application-framework)
 - MCP Server: [markmap-mcp-server](https://github.com/jinzcdev/markmap-mcp-server) [![NPM Version](https://img.shields.io/npm/v/@jinzcdev/markmap-mcp-server.svg)](https://www.npmjs.com/package/@jinzcdev/markmap-mcp-server) - powered by [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
-- AI coding agents: [mindmap-skills](https://github.com/galiacheng/mindmap-skills) - powered by [Claude Code](https://docs.claude.com/en/docs/claude-code) and [GitHub Copilot CLI](https://docs.github.com/copilot/concepts/agents/copilot-cli) skills
+- AI agents: [mindmap-skills](https://github.com/galiacheng/mindmap-skills) - generate an interactive Markmap from a file, URL, or topic, without leaving your AI agent
 
 ## Usage
 


### PR DESCRIPTION
This pull request adds a new integration to the list of available Markmap tools in the `README.md`. The update highlights support for AI agents, making it easier for users to generate interactive Markmaps through various input sources.

New integration:

* Added a reference to `mindmap-skills`, an AI agent tool that can generate interactive Markmaps from a file, URL, or topic, expanding the ecosystem for Markmap users.